### PR TITLE
Remap source paths for debugging server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,10 +35,10 @@
             "timeout": 20000,
             "outFiles": [
                 "${workspaceFolder}/server/out/**/*.js"
-            ]//,
-            // "sourceMapPathOverrides": {
-            //     "webpack://matlab-language-server/*": "${workspaceFolder}/server/*",
-            // }
+            ],
+            "sourceMapPathOverrides": {
+                "webpack://matlab-language-server/*": "${workspaceFolder}/server/*",
+            }
         }
 	],
     "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,10 +35,10 @@
             "timeout": 20000,
             "outFiles": [
                 "${workspaceFolder}/server/out/**/*.js"
-            ],
-            "sourceMapPathOverrides": {
-                "webpack://matlab-language-server/*": "${workspaceFolder}/server/*",
-            }
+            ]//,
+            // "sourceMapPathOverrides": {
+            //     "webpack://matlab-language-server/*": "${workspaceFolder}/server/*",
+            // }
         }
 	],
     "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,10 @@
             "timeout": 20000,
             "outFiles": [
                 "${workspaceFolder}/server/out/**/*.js"
-            ]
+            ],
+            "sourceMapPathOverrides": {
+                "webpack://matlab-language-server/*": "${workspaceFolder}/server/*",
+            }
         }
 	],
     "compounds": [


### PR DESCRIPTION
This coupled with the `"sourceMap": true,` change from https://github.com/mathworks/MATLAB-language-server/pull/1 fixes debugging the server TS files.