### PR TITLE
Fix test workflow for pull requests

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,20 +1,20 @@
 # Run Extension tests
 
-name: test
+name: test-pull-request
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push events for the "main" branch
-  push:
-    branches: [ main ]
+  # Triggers the workflow on pull request that contain the label 'safe to test'
+pull_request_target:
+    types: [ labeled ]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+permissions: {}    
 
 jobs:
   test-smoke:
     name: smoke-${{ matrix.version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +30,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          ref: "refs/pull/${{ github.event.number }}/merge"
+          persist-credentials: false
+      - name: Verify Head^
+        run: |
+          if [ "$(git rev-parse HEAD^)" != "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "HEAD^ does not match github.event.pull_request.head.sha"
+            exit 1
+          fi
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
         with:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -28,6 +28,7 @@ jobs:
           ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false
       - name: Verify Head^
+        shell: bash
         run: |
           if [ "$(git rev-parse HEAD^)" != "${{ github.event.pull_request.head.sha }}" ]; then
             echo "HEAD^ does not match github.event.pull_request.head.sha"

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -4,8 +4,8 @@ name: test-pull-request
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on pull request that contain the label 'safe to test'
-pull_request_target:
+  # Triggers the workflow on pull requests that contain the label 'safe to test'
+  pull_request_target:
     types: [ labeled ]
 
 permissions: {}    

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Verify Head
         shell: bash
         run: |
-          if [ "$(git ls-remote origin ${{ github.event.number }}/head)" != "${{ github.event.pull_request.head.sha }}" ]; then
+          if [ "$(git ls-remote origin ${{ github.event.number }}/head | awk '{print $1}')" != "${{ github.event.pull_request.head.sha }}" ]; then
             echo "HEAD does not match github.event.pull_request.head.sha"
             exit 1
           fi

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Verify Head
         shell: bash
         run: |
-          if [ "$(git rev-parse HEAD)" != "${{ github.event.pull_request.head.sha }}" ]; then
+          if [ "$(git ls-remote origin ${{ github.event.number }}/head)" != "${{ github.event.pull_request.head.sha }}" ]; then
             echo "HEAD does not match github.event.pull_request.head.sha"
             exit 1
           fi

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -27,11 +27,11 @@ jobs:
           submodules: recursive
           ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false
-      - name: Verify Head^
+      - name: Verify Head
         shell: bash
         run: |
-          if [ "$(git rev-parse HEAD^)" != "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "HEAD^ does not match github.event.pull_request.head.sha"
+          if [ "$(git rev-parse HEAD)" != "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "HEAD does not match github.event.pull_request.head.sha"
             exit 1
           fi
       - name: Set up MATLAB

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,4 +1,4 @@
-# Run Extension tests
+# Run tests on a pull request after it has been labeled 'safe to test'
 
 name: test-pull-request
 
@@ -20,11 +20,6 @@ jobs:
       matrix:
         version: [R2021b, R2023a]
         os: [windows-latest, ubuntu-latest]
-    env:
-        MATHWORKS_SKIP_ACTIVATION: true
-        MLM_WEB_LICENSE: true
-        MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}
-        MLM_WEB_USER_CRED: ${{secrets.MLM_WEB_USER_CRED}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,6 +37,8 @@ jobs:
         uses: matlab-actions/setup-matlab@v1.2.3
         with:
           release: ${{ matrix.version }}
+        env:
+          MATHWORKS_SKIP_ACTIVATION: true        
       - name: Setup node
         uses: actions/setup-node@v3.5.1
       - name: npm clean install
@@ -53,4 +50,7 @@ jobs:
       - name: Run tests
         run: npm run test
         env:
+          MLM_WEB_LICENSE: true
+          MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}
+          MLM_WEB_USER_CRED: ${{secrets.MLM_WEB_USER_CRED}}
           DISPLAY: ":17.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ name: test
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: [ main ]
+  pull_request_target:
+    types: [ labeled ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -17,6 +17,7 @@ jobs:
   test-smoke:
     name: smoke-${{ matrix.version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')}}
     strategy:
       fail-fast: false
       matrix:
@@ -28,10 +29,17 @@ jobs:
         MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}
         MLM_WEB_USER_CRED: ${{secrets.MLM_WEB_USER_CRED}}
     steps:
-      - name: Check out repository
+      - name: Checkout
+        if: ${{ github.event_name == 'push'}}
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Checkout merge
+        if: ${{ github.event_name == 'pull_request_target'}}
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
         with:
@@ -48,4 +56,3 @@ jobs:
         run: npm run test
         env:
           DISPLAY: ":17.0"
-          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Checkout merge 
+      - name: Checkout merge
         if: ${{ github.event_name == 'pull_request_target'}}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,6 @@ jobs:
       matrix:
         version: [R2021b, R2023a]
         os: [windows-latest, ubuntu-latest]
-    env:
-        MATHWORKS_SKIP_ACTIVATION: true
-        MLM_WEB_LICENSE: true
-        MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}
-        MLM_WEB_USER_CRED: ${{secrets.MLM_WEB_USER_CRED}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,6 +29,8 @@ jobs:
         uses: matlab-actions/setup-matlab@v1.2.3
         with:
           release: ${{ matrix.version }}
+        env:
+          MATHWORKS_SKIP_ACTIVATION: true   
       - name: Setup node
         uses: actions/setup-node@v3.5.1
       - name: npm clean install
@@ -45,4 +42,7 @@ jobs:
       - name: Run tests
         run: npm run test
         env:
+          MLM_WEB_LICENSE: true
+          MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}
+          MLM_WEB_USER_CRED: ${{secrets.MLM_WEB_USER_CRED}}
           DISPLAY: ":17.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Checkout merge
+      - name: Checkout merge 
         if: ${{ github.event_name == 'pull_request_target'}}
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Use pull_request_target, but allow the workflow to run only after the PR has a 'safe to test' label.