### PR TITLE
Remove folding markers in favor of indentation-based folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent packaging of .github folder into extension
+- Code folding no longer matches `end` when used in strings, comments, and to denote the end of a matrix
 
 ## [1.0.2] - 2023-05-05
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -75,12 +75,6 @@
             "\""
         ]
     ],
-    "folding": {
-        "markers": {
-            "start": "^\\s*\\b(?:for|parfor|spmd|if|while|try|switch|function|classdef|properties|enumeration|events|methods|arguments)\\b",
-            "end": "\\bend\\b"
-        }
-    },
     "indentationRules": {
         "increaseIndentPattern": "^\\s*\\b(?:for|parfor|spmd|if|elseif|else|while|try|catch|switch|function|classdef|properties|enumeration|events|methods|arguments)\\b",
         "decreaseIndentPattern": "^\\s*\\b(?:elseif|else|catch|end)\\b"


### PR DESCRIPTION
This change removes the folding markers from the language configuration, in favor of indentation-based folding. Primarily, this prevents code folding from matching with an incorrect `end`, such as one within a string or comment, or an `end` being used to denote the end of a matrix.

This change does have a slight functional change, in that the `end` is no longer folded. For example,
<img width="95" alt="newFolding" src="https://github.com/mathworks/MATLAB-extension-for-vscode/assets/12896371/d336030a-f390-4b8f-b325-d418941fdc4d">
compared to
<img width="94" alt="oldFolding" src="https://github.com/mathworks/MATLAB-extension-for-vscode/assets/12896371/07588c9c-3d48-4fc5-b038-b7edb8134542">

Additionally, this may limit folding being available for functions formatted with the `Classic` function indenting format in MATLAB, due to the code not being indented within the function.

This can be improved upon in the future by adding a folding range provided to the language server.