### PR TITLE
Enable smoke tests to run on mac

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [R2021b, R2023a]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [R2021b, R2023a]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [R2021b, R2023a]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [macos-13, macos-11	, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [R2021b, R2023a]
-        os: [macos-13, macos-11	, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [R2021b, R2023a]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -3,6 +3,7 @@
 import * as path from 'path'
 import { runTests } from '@vscode/test-electron'
 import { GlobSync } from 'glob'
+import * as os from 'os'
 
 async function main (): Promise<void> {
     try {
@@ -28,7 +29,8 @@ async function main (): Promise<void> {
                     version,
                     extensionDevelopmentPath,
                     extensionTestsPath,
-                    extensionTestsEnv: { test }
+                    extensionTestsEnv: { test },
+                    launchArgs: ['--user-data-dir', `${os.tmpdir()}`]
                 })
             }
         }

--- a/src/test/suite/connection/fileOnDisk.test.ts
+++ b/src/test/suite/connection/fileOnDisk.test.ts
@@ -1,20 +1,13 @@
 // Copyright 2023 The MathWorks, Inc.
-
-import { before } from 'mocha'
 import * as vs from '../../tester/VSCodeTester'
 
 suite('Connection Smoke Tests - File On Disk', () => {
-    before(async () => {
-        await vs.closeAllDocuments()
-    })
-
     test('MATLAB should connect on opening a file from disk', async () => {
         await vs.openDocument('hScript1.m')
         await vs.assertMATLABConnected()
         // test format action to verify the connection is working
         await vs.formatActiveDocument()
         await vs.assertActiveDocumentContent('if true\n    disp hello\nend\n', 'Document content should be formatted')
-        await vs.closeActiveDocument()
     })
 
     test('Format should trigger MATLAB connection', async () => {
@@ -24,6 +17,5 @@ suite('Connection Smoke Tests - File On Disk', () => {
         await vs.formatActiveDocument()
         await vs.assertMATLABConnected()
         await vs.assertActiveDocumentContent('if true\n    disp hello\nend\n', 'Document content should be formatted')
-        await vs.closeActiveDocument()
     })
 })

--- a/src/test/suite/connection/newBuffer.test.ts
+++ b/src/test/suite/connection/newBuffer.test.ts
@@ -1,16 +1,9 @@
 // Copyright 2023 The MathWorks, Inc.
-
-import { before } from 'mocha'
 import * as vs from '../../tester/VSCodeTester'
 
 suite('Connection Smoke Tests - New Buffer', () => {
-    before(async () => {
-        await vs.closeAllDocuments()
-    })
-
     test('Creating a new m file should trigger MATLAB connection', async () => {
         await vs.openNewDocument()
         await vs.assertMATLABConnected()
-        await vs.closeActiveDocument()
     })
 })

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -2,6 +2,8 @@
 
 import * as path from 'path'
 import * as Mocha from 'mocha'
+import * as vs from '../tester/VSCodeTester'
+import * as os from 'os'
 
 export async function run (): Promise<void> {
     // Create the mocha test
@@ -9,6 +11,18 @@ export async function run (): Promise<void> {
         ui: 'tdd',
         color: true,
         timeout: 600000 // set suite timeout to 10 minutes
+    })
+
+    mocha.suite.beforeAll(async function () {
+        // if on a mac, try to find the matlab install path and update the settings
+        if (os.platform() === 'darwin') {
+            const installPath = await vs._getInstallPathForMac()
+            await vs.setInstallPath(installPath)
+        }
+    })
+
+    mocha.suite.beforeEach(async function () {
+        await vs.closeAllDocuments()
     })
 
     const testsRoot = path.resolve(__dirname)

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -107,7 +107,10 @@ export async function _getInstallPathForMac (): Promise<string> {
     const matlabAppRegex = /^MATLAB_/
     const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
     if (matlabAppFile !== undefined) {
-        const filePath = path.join(directory, matlabAppFile)
+        let filePath = path.join(directory, matlabAppFile)
+        if (!filePath.endsWith('.app')) {
+            filePath += '.app';
+          }
         console.log('MATLAB installation path: ', filePath)
         return filePath
     } else {

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -109,8 +109,8 @@ export async function _getInstallPathForMac (): Promise<string> {
     if (matlabAppFile !== undefined) {
         let filePath = path.join(directory, matlabAppFile)
         if (!filePath.endsWith('.app')) {
-            filePath += '.app';
-          }
+            filePath += '.app'
+        }
         console.log('MATLAB installation path: ', filePath)
         return filePath
     } else {

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -109,7 +109,17 @@ export async function _getInstallPathForMac (): Promise<string> {
     if (matlabAppFile !== undefined) {
         let filePath = path.join(directory, matlabAppFile)
         if (!filePath.endsWith('.app')) {
-            filePath += '.app'
+            const innerDirectory = filePath
+            const innerFiles = await fs.readdir(innerDirectory)
+            innerFiles.forEach(file => {
+                console.log(file)
+            })
+            const innerMatlabAppFile = innerFiles.find((file: string) => matlabAppRegex.test(file))
+            if (innerMatlabAppFile !== undefined) {
+                filePath = path.join(innerDirectory, innerMatlabAppFile)
+            } else {
+                throw new Error('MATLAB installation not found (inner).')
+            }
         }
         console.log('MATLAB installation path: ', filePath)
         return filePath

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -104,8 +104,10 @@ export async function closeAllDocuments (): Promise<void> {
 export async function _getInstallPathForMac (): Promise<string> {
     const directory = '/Applications'
     const files = await fs.readdir(directory)
-    console.log(files)
-    const matlabAppRegex = /^MATLAB\w+\.app$/
+    files.forEach(file => {
+        console.log(file)
+    })
+    const matlabAppRegex = /^MATLAB_\w+\.app$/
     const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
     if (matlabAppFile !== undefined) {
         const filePath = path.join(directory, matlabAppFile)

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -102,8 +102,9 @@ export async function closeAllDocuments (): Promise<void> {
  * Search in the /Applications/ dir and return the path of an installed MATLAB on a Mac.
  */
 export async function _getInstallPathForMac (): Promise<string> {
-    const directory = '/Applications/'
+    const directory = '/Applications'
     const files = await fs.readdir(directory)
+    console.log(files)
     const matlabAppRegex = /^MATLAB\w+\.app$/
     const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
     if (matlabAppFile !== undefined) {

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as extension from '../../extension'
 import * as PollingUtils from './PollingUtils'
+import * as fs from 'fs/promises'
 
 /**
  * Change 'MATLAB Connection' to connect to MATLAB
@@ -95,4 +96,28 @@ export async function closeActiveDocument (): Promise<void> {
  */
 export async function closeAllDocuments (): Promise<void> {
     return await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+}
+
+/**
+ * Search in the /Applications/ dir and return the path of an installed MATLAB on a Mac.
+ */
+export async function _getInstallPathForMac (): Promise<string> {
+    const directory = '/Applications/'
+    const files = await fs.readdir(directory)
+    const matlabAppRegex = /^MATLAB\w+\.app$/
+    const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
+    if (matlabAppFile !== undefined) {
+        const filePath = path.join(directory, matlabAppFile)
+        console.log('MATLAB installation path: ', filePath)
+        return filePath
+    } else {
+        throw new Error('MATLAB installation not found.')
+    }
+}
+
+/**
+ * Update extension settings with the provided MATLAB install path.
+ */
+export async function setInstallPath (path: string): Promise<void> {
+    return await vscode.workspace.getConfiguration('MATLAB').update('installPath', path, true)
 }

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -99,15 +99,12 @@ export async function closeAllDocuments (): Promise<void> {
 }
 
 /**
- * Search in the /Applications/ dir and return the path of an installed MATLAB on a Mac.
+ * Search the /Applications/ dir and return the path of an installed MATLAB.
  */
 export async function _getInstallPathForMac (): Promise<string> {
     const directory = '/Applications'
     const files = await fs.readdir(directory)
-    files.forEach(file => {
-        console.log(file)
-    })
-    const matlabAppRegex = /^MATLAB_\w+\.app$/
+    const matlabAppRegex = /^MATLAB_/
     const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
     if (matlabAppFile !== undefined) {
         const filePath = path.join(directory, matlabAppFile)


### PR DESCRIPTION
- Refactoring the test suite so the default `before` and `beforeEach` do not need to be written for each test file.
- For mac, try to find a `MATLAB_Rxxxxx.app` in the `/Applications/` or `/Applications/ MATLAB_Rxxxxx/` dir and use it to update the extension setting in `before` 
- Running consecutive tests fail on mac as the default `--user-data-dir` is long so use the OS temp dir instead.
- The test: `MATLAB should connect on opening a file from disk` fails on `macos-12` and `macos-11`, but I have not been able to reproduce the test failure locally or interactively on `macos-12`.  Enabling the tests with `macos-13` to begin with while I look into the failures.
