### PR TITLE
test nightly on insiders version

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,12 +1,11 @@
-# Run Extension tests
+# Run extension tests nightly on vscode insiders version
 
-name: test
+name: test-nightly
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push events for the "main" branch
-  push:
-    branches: [ main ]
+  schedule:
+    - cron: "45 11 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -40,7 +39,7 @@ jobs:
         shell: bash
         if: ${{ success() && matrix.os == 'ubuntu-latest' }}
       - name: Run tests
-        run: npm run test
+        run: npm run test-insiders
         env:
           MLM_WEB_LICENSE: true
           MLM_WEB_ID: ${{secrets.MLM_WEB_ID}}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
 		"lint": "eslint src --ext ts",
 		"lint:fix": "eslint src --ext ts --fix",
 		"test": "node ./out/test/runTest.js",
+		"test-insiders": "node ./out/test/runTest.js --insiders",
 		"postinstall": "cd server && npm install && cd ..",
 		"package": "vsce package"
 	},

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -8,7 +8,12 @@ import * as os from 'os'
 async function main (): Promise<void> {
     try {
         // Run the test against minimum supported and latest stable VS Code version
-        const versions = ['1.67.0', 'stable']
+        let versions = ['1.67.0', 'stable']
+
+        // If insiders argument is specified in CLI, run only against insiders version instead
+        if (process.argv.includes('--insiders')) {
+            versions = ['insiders']
+        }
 
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`


### PR DESCRIPTION
Run daily tests against insiders version instead of 1.67.0 and latest.
Adding a separate yml file to be able to track nightly runs separately in the actions tab.