### PR TITLE
MATLAB extension for VS Code - v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.6] - 2024-01-12
+## [1.1.6] - 2024-01-16
 
 ### Fixed
 - Enabled language server features in untitled MATLAB files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Enabled language server features in untitled MATLAB files
+- Fixed linting with mlint on Windows
+- Fixed regression with code navigation when using with MATLAB R2024a
 
 ## [1.1.5] - 2023-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Enabled language server features in untitled MATLAB files
+
 ## [1.1.5] - 2023-12-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6] - 2024-01-12
+
 ### Fixed
 - Enabled language server features in untitled MATLAB files
 - Fixed linting with mlint on Windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.1.5",
+			"version": "1.1.6",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"engines": {
 		"vscode": "^1.67.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 - 2023 The MathWorks, Inc.
+// Copyright 2022 - 2024 The MathWorks, Inc.
 
 import * as path from 'path'
 import * as vscode from 'vscode'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
-        documentSelector: [{ scheme: 'file', language: 'matlab' }]
+        documentSelector: ['matlab']
     }
 
     // Create and start the language client


### PR DESCRIPTION
Preparing changes for v1.1.6 update of the MALTAB extension for VS Code.

See CHANGELOG.md for the changes included.