### PR TITLE
Update GitHub actions workflows

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,21 +17,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, R2023a]
+        version: [R2021b, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1.2.3
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-        env:
-          MATHWORKS_SKIP_ACTIVATION: true   
+          cache: true
       - name: Setup node
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
       - name: npm clean install
         run: npm ci
       - name: Start Xvfb 

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, latest]
+        version: [R2021a, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -28,7 +28,6 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-          cache: true
       - name: Setup node
         uses: actions/setup-node@v4
       - name: npm clean install

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, latest]
+        version: [R2021a, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -38,7 +38,6 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-          cache: true
       - name: Setup node
         uses: actions/setup-node@v4
       - name: npm clean install

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, R2023a]
+        version: [R2021b, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: "refs/pull/${{ github.event.number }}/merge"
@@ -35,13 +35,12 @@ jobs:
             exit 1
           fi
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1.2.3
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-        env:
-          MATHWORKS_SKIP_ACTIVATION: true        
+          cache: true
       - name: Setup node
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
       - name: npm clean install
         run: npm ci
       - name: Start Xvfb 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, R2023a]
+        version: [R2021b, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1.2.3
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-        env:
-          MATHWORKS_SKIP_ACTIVATION: true   
+          cache: true
       - name: Setup node
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
       - name: npm clean install
         run: npm ci
       - name: Start Xvfb 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [R2021b, latest]
+        version: [R2021a, latest]
         os: [windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.version }}
-          cache: true
       - name: Setup node
         uses: actions/setup-node@v4
       - name: npm clean install

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -3,7 +3,6 @@
 import * as path from 'path'
 import * as Mocha from 'mocha'
 import * as vs from '../tester/VSCodeTester'
-import * as os from 'os'
 
 export async function run (): Promise<void> {
     // Create the mocha test

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -13,14 +13,6 @@ export async function run (): Promise<void> {
         timeout: 600000 // set suite timeout to 10 minutes
     })
 
-    mocha.suite.beforeAll(async function () {
-        // if on a mac, try to find the matlab install path and update the settings
-        if (os.platform() === 'darwin') {
-            const installPath = await vs._getInstallPathForMac()
-            await vs.setInstallPath(installPath)
-        }
-    })
-
     mocha.suite.beforeEach(async function () {
         await vs.closeAllDocuments()
     })

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import * as extension from '../../extension'
 import * as PollingUtils from './PollingUtils'
-import * as fs from 'fs/promises'
 
 /**
  * Change 'MATLAB Connection' to connect to MATLAB

--- a/src/test/tester/VSCodeTester.ts
+++ b/src/test/tester/VSCodeTester.ts
@@ -99,27 +99,6 @@ export async function closeAllDocuments (): Promise<void> {
 }
 
 /**
- * Search the /Applications/ dir and return the path of an installed MATLAB.
- */
-export async function _getInstallPathForMac (): Promise<string> {
-    const directory = '/Applications'
-    const files = await fs.readdir(directory)
-    const matlabAppRegex = /^MATLAB_/
-    const matlabAppFile = files.find((file: string) => matlabAppRegex.test(file))
-    if (matlabAppFile !== undefined) {
-        let filePath = path.join(directory, matlabAppFile)
-        // if a folder was detected, the app file must be in that folder
-        if (!filePath.endsWith('.app')) {
-            filePath = path.join(directory, matlabAppFile, `${matlabAppFile}.app`)
-        }
-        console.log('MATLAB installation path: ', filePath)
-        return filePath
-    } else {
-        throw new Error('MATLAB installation not found.')
-    }
-}
-
-/**
  * Get the current extension setting for MATLAB install path.
  */
 export function _getInstallPath (): string {


### PR DESCRIPTION
This change updates all GitHub Actions workflows to use the newest version of actions, the most relevant being `setup-matlab@v2`. It also modifies the tests to run against R2021a and latest, rather than R2021b and R2023a, which more closely aligns with the range of releases the extension supports.

The special-case search for the macOS MATLAB install path was also removed because `setup-matlab@v2` installs MATLAB into the runner tool cache, which is not under /Applications. The standard logic used to find MATLAB via the system PATH appears to be sufficient on all platforms and is relied upon instead.