### PR TITLE
MATLAB extension for VS Code - v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Extension now works with the New Desktop for MATLAB
 
+### Fixed
+- Fixed launching App Designer and Simulink through MATLAB code execution
+
 ## [1.2.0] - 2024-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2024-04-04
+
+### Added
+- Extension now works with the New Desktop for MATLAB
+
 ## [1.2.0] - 2024-03-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"engines": {
 		"vscode": "^1.67.0"
 	},


### PR DESCRIPTION
Preparing changes for v1.2.1 update of the MATLAB extension for VS Code.

See CHANGELOG.md for the changes included.

Resolves #99
Resolves #24