### PR TITLE
MATLAB extension for VS Code - v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2024-05-17
+
 ### Changed
 - Tweaks to telemetry logging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"engines": {
 		"vscode": "^1.67.0"
 	},


### PR DESCRIPTION
Preparing changes for v1.2.2 update of the MATLAB extension for VS Code.

See CHANGELOG.md for the changes included.

Resolves #76
Resolves #78 