### PR TITLE
MATLAB extension for VS Code - v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2024-06-11
+
+### Notice
+- This extension will no longer support MATLAB R2021a in a future release. To make use of the advanced features of the extension or run MATLAB code, you will need to have MATLAB R2021b or later installed.
+
+### Added
+- Popups will be shown to inform the user when the connected MATLAB is not supported by the extension, or if support is planned to be removed in a future update.
+
+### Fixed
+- Resolved issue with connecting to Intel MATLAB installation on Apple Silicon machines
+- Resolved error if MATLAB process is killed unexpectedly
+- Fixed bug where "never" startup timing was ignored
+
 ## [1.2.2] - 2024-05-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This extension provides support for editing and running MATLAB&reg; code in Visu
 
 You can use this extension with or without MATLAB installed on your system. However, to make use of the advanced features of the extension or run MATLAB code, you must have MATLAB R2021a or later installed. For more information, see the [Get Started](#get-started) section.
 
+**Note:** This extension will no longer support MATLAB R2021a in a future release. To make use of the advanced features of the extension or run MATLAB code, you will need to have MATLAB R2021b or later installed.
+
 For an overview of some of the major features of this extension, you can watch the [Introducing the New MATLAB Extension for Visual Studio Code](https://www.youtube.com/watch?v=kYTBAr9LlGg) video.
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.2.2",
+			"version": "1.2.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1362,12 +1362,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2854,9 +2854,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -7530,12 +7530,12 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"browser-stdout": {
@@ -8626,9 +8626,9 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"engines": {
 		"vscode": "^1.67.0"
 	},
@@ -56,6 +56,10 @@
 			{
 				"command": "matlab.changeDirectory",
 				"title": "MATLAB: Change current directory"
+			},
+			{
+				"command": "matlab.resetDeprecationPopups",
+				"title": "MATLAB: Reset Deprecation Warning Popups"
 			}
 		],
 		"keybindings": [

--- a/src/DeprecationPopupService.ts
+++ b/src/DeprecationPopupService.ts
@@ -1,0 +1,222 @@
+// Copyright 2024 The MathWorks, Inc.
+
+import * as vscode from 'vscode'
+import { LanguageClient } from 'vscode-languageclient/node'
+import Notification from './Notifications'
+
+enum DeprecationType {
+    NEVER_SUPPORTED = 1,
+    DEPRECATED = 2,
+    TO_BE_DEPRECATED = 3
+}
+
+interface PopupInfo {
+    message: string
+    options: string[]
+}
+
+interface MessageData {
+    deprecationType: DeprecationType
+    deprecationInfo: DeprecationInfo
+}
+
+interface DeprecationInfo {
+    /**
+     * The version of MATLAB which has been launched
+     */
+    matlabVersion: string
+
+    /**
+     * The minimum supported release of MATLAB (support may be ending soon)
+     */
+    minVersion: string
+
+    /**
+     * The future minimum supported release of MATLAB. This may be greater
+     * than the `minVersion` if support for `minVersion` is planned to end.
+     */
+    futureMinVersion: string
+}
+
+interface StoredPopupConfig {
+    /**
+     * Contains saved config for when the popup should not be shown.
+     */
+    hidePopupFor: {
+        /**
+         * The deprecated releases of MATLAB for which the user has
+         * chosen "Do not show again for <release>"
+         */
+        deprecated: string[]
+
+        /**
+         * The to-be-deprecated releases of MATLAB for which the user has
+         * chosen "Do not show again for <release>"
+         */
+        toBeDeprecated: string[]
+    }
+}
+
+const GLOBAL_STORAGE_KEY = 'matlab.deprecation.popup'
+
+/**
+ * Service to handle notifications from the MATLAB language server when a
+ * launched MATLAB version is no longer supported (or is on a deprecation
+ * track) by the language server.
+ */
+export default class DeprecationPopupService {
+    constructor (private readonly context: vscode.ExtensionContext) {}
+
+    /**
+     * Initializes the service to listen to notifications from the language server.
+     *
+     * @param client The language server client
+     */
+    initialize (client: LanguageClient): void {
+        this.context.subscriptions.push(
+            client.onNotification(Notification.MatlabVersionDeprecation, (data: MessageData) => {
+                this.showDeprecationPopup(data.deprecationType, data.deprecationInfo)
+            }),
+            vscode.commands.registerCommand('matlab.resetDeprecationPopups', () => {
+                this.resetDeprecationPopupConfig()
+            })
+        )
+    }
+
+    /**
+     * Attempts to display a deprecation notification popup.
+     *
+     * @see {@link shouldShowDeprecationPopup} for details on when the popup is shown.
+     *
+     * @param deprecationType The type of depreceation message (i.e. Deprecated,
+     * Never Supported, or To-Be-Deprecated)
+     * @param deprecationInfo Contains info about the current MATLAB version as well as
+     * what versions are supported.
+     */
+    private showDeprecationPopup (deprecationType: DeprecationType, deprecationInfo: DeprecationInfo): void {
+        if (!this.shouldShowDeprecationPopup(deprecationType, deprecationInfo)) {
+            return
+        }
+
+        const { message, options } = this.getPopupInfo(deprecationType, deprecationInfo)
+
+        switch (deprecationType) {
+            case DeprecationType.TO_BE_DEPRECATED:
+                void vscode.window.showWarningMessage(message, ...options).then(choice => {
+                    this.handleChoiceClicked(deprecationType, deprecationInfo, choice)
+                })
+                break
+            case DeprecationType.NEVER_SUPPORTED:
+            case DeprecationType.DEPRECATED:
+                void vscode.window.showErrorMessage(message, ...options).then(choice => {
+                    this.handleChoiceClicked(deprecationType, deprecationInfo, choice)
+                })
+                break
+        }
+    }
+
+    /**
+     * Determines whether the deprecation popup should be shown. By default, the popup will
+     * be shown. However, if the "Do not show again" option is clicked, the popup will not
+     * be shown again in the future for this combination of deprecation type AND MATLAB version.
+     *
+     * @param deprecationType The type of depreceation message (i.e. Deprecated,
+     * Never Supported, or To-Be-Deprecated)
+     * @param deprecationInfo Contains info about the current MATLAB version as well as
+     * what versions are supported.
+     */
+    private shouldShowDeprecationPopup (deprecationType: DeprecationType, deprecationInfo: DeprecationInfo): boolean {
+        const config: StoredPopupConfig | undefined = this.context.globalState.get(GLOBAL_STORAGE_KEY)
+
+        if (config === undefined) {
+            // No saved config - show popup
+            return true
+        } else {
+            const { matlabVersion } = deprecationInfo
+            const isInDeprecated = config.hidePopupFor.deprecated.includes(matlabVersion)
+            const isInToBeDeprecated = config.hidePopupFor.toBeDeprecated.includes(matlabVersion)
+
+            if (deprecationType === DeprecationType.DEPRECATED && isInDeprecated) {
+                return false
+            } else if (deprecationType === DeprecationType.TO_BE_DEPRECATED && isInToBeDeprecated) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    /**
+     * Gets the message and options to display on the popup.
+     *
+     * @param deprecationType The type of depreceation message (i.e. Deprecated,
+     * Never Supported, or To-Be-Deprecated)
+     * @param deprecationInfo Contains info about the current MATLAB version as well as
+     * what versions are supported.
+     */
+    private getPopupInfo (deprecationType: DeprecationType, deprecationInfo: DeprecationInfo): PopupInfo {
+        let message = ''
+        const options = ['Dismiss']
+
+        if (deprecationType === DeprecationType.NEVER_SUPPORTED) {
+            message = `This extension does not support MATLAB ${deprecationInfo.matlabVersion}. To make use of the advanced features of the extension or run MATLAB code, you must have MATLAB ${deprecationInfo.minVersion} or later installed.`
+        } else if (deprecationType === DeprecationType.DEPRECATED) {
+            message = `This extension no longer supports MATLAB ${deprecationInfo.matlabVersion}. To make use of the advanced features of the extension or run MATLAB code, you must have MATLAB ${deprecationInfo.minVersion} or later installed.`
+            options.push(`Do not show again for ${deprecationInfo.matlabVersion}`)
+        } else if (deprecationType === DeprecationType.TO_BE_DEPRECATED) {
+            message = `This extension will no longer support MATLAB ${deprecationInfo.matlabVersion} in a future release. To make use of the advanced features of the extension or run MATLAB code, you will need to have MATLAB ${deprecationInfo.futureMinVersion} or later installed.`
+            options.push(`Do not show again for ${deprecationInfo.matlabVersion}`)
+        }
+
+        return {
+            message,
+            options
+        }
+    }
+
+    /**
+     * Handles the user's choice within the popup.
+     *
+     * @param deprecationType The type of depreceation message (i.e. Deprecated,
+     * Never Supported, or To-Be-Deprecated)
+     * @param deprecationInfo Contains info about the current MATLAB version as well as
+     * what versions are supported.
+     * @param choice the user's choice, or undefined if the user dismissed the popup without selecting an option
+     */
+    private handleChoiceClicked (deprecationType: DeprecationType, deprecationInfo: DeprecationInfo, choice?: string): void {
+        if (choice == null) {
+            return
+        }
+
+        if (choice?.startsWith('Do not show again for')) {
+            // Need to update the stored config to hide this popup for this scenario
+            let config: StoredPopupConfig | undefined = this.context.globalState.get(GLOBAL_STORAGE_KEY)
+
+            if (config === undefined) {
+                // No current config - need to create config object
+                config = {
+                    hidePopupFor: {
+                        deprecated: [],
+                        toBeDeprecated: []
+                    }
+                }
+            }
+
+            if (deprecationType === DeprecationType.DEPRECATED) {
+                config.hidePopupFor.deprecated.push(deprecationInfo.matlabVersion)
+            } else if (deprecationType === DeprecationType.TO_BE_DEPRECATED) {
+                config.hidePopupFor.toBeDeprecated.push(deprecationInfo.matlabVersion)
+            }
+
+            void this.context.globalState.update(GLOBAL_STORAGE_KEY, config)
+        }
+    }
+
+    /**
+     * Resets the stored configuration for the deprecation popups, allowing
+     * them to appear again.
+     */
+    private resetDeprecationPopupConfig (): void {
+        void this.context.globalState.update(GLOBAL_STORAGE_KEY, undefined)
+    }
+}

--- a/src/Notifications.ts
+++ b/src/Notifications.ts
@@ -10,6 +10,9 @@ enum Notification {
     MatlabFeatureUnavailable = 'feature/needsmatlab',
     MatlabFeatureUnavailableNoMatlab = 'feature/needsmatlab/nomatlab',
 
+    // MATLAB Version Deprecation
+    MatlabVersionDeprecation = 'matlab/version/deprecation',
+
     // Execution
     MatlabRequestInstance = 'matlab/request',
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { Notifier } from './commandwindow/Utilities'
 import TerminalService from './commandwindow/TerminalService'
 import Notification from './Notifications'
 import ExecutionCommandProvider from './commandwindow/ExecutionCommandProvider'
+import DeprecationPopupService from './DeprecationPopupService'
 
 let client: LanguageClient
 
@@ -27,6 +28,8 @@ const CONNECTION_STATUS_COMMAND = 'matlab.changeMatlabConnection'
 export let connectionStatusNotification: vscode.StatusBarItem
 
 let telemetryLogger: TelemetryLogger
+
+let deprecationPopupService: DeprecationPopupService
 
 let mvm: MVM;
 let terminalService: TerminalService;
@@ -110,6 +113,9 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     context.subscriptions.push(vscode.commands.registerCommand('matlab.openCommandWindow', async () => await terminalService.openTerminalOrBringToFront()))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.changeDirectory', async (uri: vscode.Uri) => await executionCommandProvider.handleChangeDirectory(uri)))
+
+    deprecationPopupService = new DeprecationPopupService(context)
+    deprecationPopupService.initialize(client)
 
     await client.start()
 }


### PR DESCRIPTION
Prepping changes for v1.2.3 update of the MATLAB extension for VS Code.

See CHANGELOG.md for the changes included.

Resolves #110 