### PR TITLE
Opening figures, simulink models, etc. in VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Open non-code MATLAB files (e.g. `.slx`, `.fig`) via the context menu
+
 ## [1.2.7] - 2024-11-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -129,11 +129,6 @@
 					"command": "matlab.runSelection",
 					"when": "editorLangId == matlab && editorHasSelection && !editorHasMultipleSelections",
 					"group": "1_run"
-				},
-				{
-					"command": "matlab.openFile",
-					"when": "editorHasSelection",
-					"group": "files"
 				}
 			],
 			"explorer/context": [
@@ -144,6 +139,11 @@
 				{
 					"command": "matlab.changeDirectory",
 					"when": "explorerResourceIsFolder"
+				},
+				{
+					"command": "matlab.openFile",
+					"when": "!explorerResourceIsFolder",
+					"group": "files"
 				}
 			],
 			"matlab.addPath": [

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
 				},
 				{
 					"command": "matlab.openFile",
-					"when": "editorLangId == matlab && editorHasSelection && resourceExtname != '.m'"
+					"when": "editorHasSelection",
+					"group": "files"
 				}
 			],
 			"explorer/context": [

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
 				"title": "MATLAB: Manage Sign In Options"
 			},
 			{
+				"command": "matlab.openFile",
+				"title": "MATLAB: Open File"
+			},
+			{
 				"command": "matlab.resetDeprecationPopups",
 				"title": "MATLAB: Reset Deprecation Warning Popups"
 			}
@@ -125,6 +129,10 @@
 					"command": "matlab.runSelection",
 					"when": "editorLangId == matlab && editorHasSelection && !editorHasMultipleSelections",
 					"group": "1_run"
+				},
+				{
+					"command": "matlab.openFile",
+					"when": "editorLangId == matlab && editorHasSelection && resourceExtname != '.m'"
 				}
 			],
 			"explorer/context": [

--- a/src/commandwindow/ExecutionCommandProvider.ts
+++ b/src/commandwindow/ExecutionCommandProvider.ts
@@ -297,4 +297,29 @@ export default class ExecutionCommandProvider {
 
         void this._mvm.feval('cd', 0, [uri.fsPath]);
     }
+
+    /**
+     * Implements the open file action
+     * @param uri The file path to the file that should be opened
+     * @returns
+     */
+    async handleOpenFile(uri: vscode.Uri): Promise<void> {
+        this._telemetryLogger.logEvent({
+            eventKey: 'ML_VS_CODE_ACTIONS',
+            data: {
+                action_type: 'openFile',
+                result: ''
+            }
+        });
+
+        await this._terminalService.openTerminalOrBringToFront();
+
+        try {
+            await this._mvm.getReadyPromise();
+        } catch (e) {
+            return;
+        }
+
+        void this._mvm.feval('open', 0, [uri.fsPath]);
+    }
 }

--- a/src/commandwindow/ExecutionCommandProvider.ts
+++ b/src/commandwindow/ExecutionCommandProvider.ts
@@ -300,10 +300,10 @@ export default class ExecutionCommandProvider {
 
     /**
      * Implements the open file action
-     * @param uris The file paths to the files that should be opened
+     * @param uri The file path to the file that should be opened
      * @returns
      */
-    async handleOpenFile (uris: vscode.Uri[]): Promise<void> {
+    async handleOpenFile(uri: vscode.Uri): Promise<void> {
         this._telemetryLogger.logEvent({
             eventKey: 'ML_VS_CODE_ACTIONS',
             data: {
@@ -320,8 +320,6 @@ export default class ExecutionCommandProvider {
             return;
         }
 
-        for (const uri of uris) {
-            void this._mvm.feval('open', 0, [uri.fsPath]);
-        }
+        void this._mvm.feval('open', 0, [uri.fsPath]);
     }
 }

--- a/src/commandwindow/ExecutionCommandProvider.ts
+++ b/src/commandwindow/ExecutionCommandProvider.ts
@@ -303,7 +303,7 @@ export default class ExecutionCommandProvider {
      * @param uri The file path to the file that should be opened
      * @returns
      */
-    async handleOpenFile(uri: vscode.Uri): Promise<void> {
+    async handleOpenFile (uri: vscode.Uri): Promise<void> {
         this._telemetryLogger.logEvent({
             eventKey: 'ML_VS_CODE_ACTIONS',
             data: {

--- a/src/commandwindow/ExecutionCommandProvider.ts
+++ b/src/commandwindow/ExecutionCommandProvider.ts
@@ -300,10 +300,10 @@ export default class ExecutionCommandProvider {
 
     /**
      * Implements the open file action
-     * @param uri The file path to the file that should be opened
+     * @param uris The file paths to the files that should be opened
      * @returns
      */
-    async handleOpenFile(uri: vscode.Uri): Promise<void> {
+    async handleOpenFile (uris: vscode.Uri[]): Promise<void> {
         this._telemetryLogger.logEvent({
             eventKey: 'ML_VS_CODE_ACTIONS',
             data: {
@@ -320,6 +320,8 @@ export default class ExecutionCommandProvider {
             return;
         }
 
-        void this._mvm.feval('open', 0, [uri.fsPath]);
+        for (const uri of uris) {
+            void this._mvm.feval('open', 0, [uri.fsPath]);
+        }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderAndSubfoldersToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderAndSubfoldersToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.changeDirectory', async (uri: vscode.Uri) => await executionCommandProvider.handleChangeDirectory(uri)))
-    context.subscriptions.push(vscode.commands.registerCommand('matlab.openFile', async (uri: vscode.Uri) => await executionCommandProvider.handleOpenFile(uri)))
+    context.subscriptions.push(vscode.commands.registerCommand('matlab.openFile', async (uris: vscode.Uri[]) => await executionCommandProvider.handleOpenFile(uris)))
 
     // Register a custom command which allows the user enable / disable Sign In options.
     // Using this custom command would be an alternative approach to going to enabling the setting.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderAndSubfoldersToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderAndSubfoldersToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.changeDirectory', async (uri: vscode.Uri) => await executionCommandProvider.handleChangeDirectory(uri)))
-    context.subscriptions.push(vscode.commands.registerCommand('matlab.openFile', async (uris: vscode.Uri[]) => await executionCommandProvider.handleOpenFile(uris)))
+    context.subscriptions.push(vscode.commands.registerCommand('matlab.openFile', async (uri: vscode.Uri) => await executionCommandProvider.handleOpenFile(uri)))
 
     // Register a custom command which allows the user enable / disable Sign In options.
     // Using this custom command would be an alternative approach to going to enabling the setting.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,6 +129,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.addFolderAndSubfoldersToPath', async (uri: vscode.Uri) => await executionCommandProvider.handleAddFolderAndSubfoldersToPath(uri)))
     context.subscriptions.push(vscode.commands.registerCommand('matlab.changeDirectory', async (uri: vscode.Uri) => await executionCommandProvider.handleChangeDirectory(uri)))
+    context.subscriptions.push(vscode.commands.registerCommand('matlab.openFile', async (uri: vscode.Uri) => await executionCommandProvider.handleOpenFile(uri)))
 
     // Register a custom command which allows the user enable / disable Sign In options.
     // Using this custom command would be an alternative approach to going to enabling the setting.


### PR DESCRIPTION
Implements opening `.fig`, `.slx` and other MATLAB files through VS code's context menu.

**Note!** I'm brand new to developing in TypeScript, and I'm having some implementation issues (specifically, getting the menu option to occur in the context menu.) Still, I wanted to put this here in case @dklilley or any of the other maintainers want to help with the final steps!