### PR TITLE
MATLAB extension for VS Code - v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2025-03-06
+
+### Fixed
+- Resolves error with adding workspace folders to the MATLAB path on Unix systems
+
 ## [1.3.1] - 2025-01-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.3.1",
+			"version": "1.3.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -658,9 +658,9 @@
 			}
 		},
 		"node_modules/@redhat-developer/page-objects/node_modules/type-fest": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-			"integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+			"version": "4.34.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+			"integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -3576,9 +3576,9 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "14.4.5",
-			"resolved": "https://registry.npmjs.org/got/-/got-14.4.5.tgz",
-			"integrity": "sha512-sq+uET8TnNKRNnjEOPJzMcxeI0irT8BBNmf+GtZcJpmhYsQM1DSKmCROUjPWKsXZ5HzwD5Cf5/RV+QD9BSTxJg==",
+			"version": "14.4.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-14.4.6.tgz",
+			"integrity": "sha512-rnhwfM/PhMNJ1i17k3DuDqgj0cKx3IHxBKVv/WX1uDKqrhi2Gv3l7rhPThR/Cc6uU++dD97W9c8Y0qyw9x0jag==",
 			"dev": true,
 			"dependencies": {
 				"@sindresorhus/is": "^7.0.1",
@@ -3601,9 +3601,9 @@
 			}
 		},
 		"node_modules/got/node_modules/type-fest": {
-			"version": "4.33.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-			"integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+			"version": "4.34.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+			"integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -7842,9 +7842,9 @@
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-					"integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+					"version": "4.34.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+					"integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
 					"dev": true
 				}
 			}
@@ -9955,9 +9955,9 @@
 			}
 		},
 		"got": {
-			"version": "14.4.5",
-			"resolved": "https://registry.npmjs.org/got/-/got-14.4.5.tgz",
-			"integrity": "sha512-sq+uET8TnNKRNnjEOPJzMcxeI0irT8BBNmf+GtZcJpmhYsQM1DSKmCROUjPWKsXZ5HzwD5Cf5/RV+QD9BSTxJg==",
+			"version": "14.4.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-14.4.6.tgz",
+			"integrity": "sha512-rnhwfM/PhMNJ1i17k3DuDqgj0cKx3IHxBKVv/WX1uDKqrhi2Gv3l7rhPThR/Cc6uU++dD97W9c8Y0qyw9x0jag==",
 			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "^7.0.1",
@@ -9974,9 +9974,9 @@
 			},
 			"dependencies": {
 				"type-fest": {
-					"version": "4.33.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-					"integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+					"version": "4.34.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+					"integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"engines": {
 		"vscode": "^1.67.0"
 	},


### PR DESCRIPTION
Prepping changes for v1.3.2 update of the MATLAB extension for VS Code.

See CHANGELOG.md for the changes included.

Fixes #216 