### PR TITLE
Add tab auto completion to terminal

### DIFF
--- a/src/commandwindow/MVM.ts
+++ b/src/commandwindow/MVM.ts
@@ -4,6 +4,7 @@ import { TextEvent, FEvalResponse, EvalResponse, MVMError, BreakpointResponse, C
 import { createResolvablePromise, ResolvablePromise, Notifier } from './Utilities'
 import Notification from '../Notifications'
 import EventEmitter = require('events')
+import { CompletionItem, CompletionList, CompletionParams, DidOpenTextDocumentParams } from 'vscode-languageclient/node'
 
 /**
  * The current state of MATLAB
@@ -76,6 +77,14 @@ export class MVM extends EventEmitter {
         this._currentReadyPromise = createResolvablePromise();
 
         this._pendingUserEvals = 0;
+    }
+
+    sendNotificationDidOpen (params: DidOpenTextDocumentParams): void {
+        this._notifier.sendNotificationDidOpen(params);
+    }
+
+    sendRequestCompletion (params: CompletionParams): Thenable<CompletionItem[] | CompletionList> {
+        return this._notifier.sendRequestCompletion(params);
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,7 +123,7 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
     client.onNotification(Notification.MatlabFeatureUnavailableNoMatlab, () => handleFeatureUnavailableWithNoMatlab())
     client.onNotification(Notification.LogTelemetryData, (data: TelemetryEvent) => handleTelemetryReceived(data))
 
-    const multiclientNotifier = new MultiClientNotifier(client as Notifier);
+    const multiclientNotifier = new MultiClientNotifier(client);
     mvm = new MVM(multiclientNotifier);
     terminalService = new TerminalService(multiclientNotifier, mvm);
     executionCommandProvider = new ExecutionCommandProvider(mvm, terminalService, telemetryLogger);


### PR DESCRIPTION
This can be achieved by leveraging the existing tab autocompletion mechanism of the editor. When the user presses tab, create a fake file with the contents of the current terminal prompt and send a "textDocument/completion" request to the language server.

If there's only one completionItem, complete the current prompt with its content. If there are multiple possible completionItems, display them on the terminal.