### PR TITLE
MATLAB extension for VS Code - v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for highlighting all references to a selected function, variable, class, or class property
 
 ### Fixed
-- Resolves an issue where newly saved document contents are ignored during execution
-- Resolves an issue where section breaks are not displayed and the `Run Section` command does not work until a file is modified for the first time
+- Resolves issue where newly saved document contents are ignored during execution
+- Resolves issue where section breaks are not displayed and the `Run Section` command does not work until a file is modified for the first time.
 - Applied patch for CVE-2025-54798
 
 ## [1.3.4] - 2025-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5] - 2025-09-04
+
+### Added
+- Support for prewarming graphics to improve the performance of first-time graphics rendering 
+- Support for using Visual Studio Code as the default editor when using the MATLAB `edit` and `open` commands
+- Support for highlighting all references to a selected function, variable, class, or class property
+
+### Fixed
+- Resolves an issue where newly saved document contents are ignored during execution
+- Resolves an issue where section breaks are not displayed and the `Run Section` command does not work until a file is modified for the first time
+- Applied patch for CVE-2025-54798
+
 ## [1.3.4] - 2025-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ You also can use this extension along with the Jupyter Extension for Visual Stud
 ## Configuration
 To configure the extension, go to the extension settings and select from the available options.
 
+### MATLAB Default Editor Setting
+By default, the extension uses the editor specified in the MATLAB Editor/Debugger settings to open files with the MATLAB `edit` and `open` commands. To make Visual Studio Code the default editor for these commands, set the `MATLAB.defaultEditor` setting to `true`. To revert to using the editor specified in the MATLAB Editor/Debugger settings, set `MATLAB.defaultEditor` to `false`.
+**Note:** Certain file types always open in MATLAB by default — for example, live scripts saved in the binary Live Code file format (.mlx) and MATLAB app files (.mlapp).
+
 ### MATLAB Install Path Setting
 If you have MATLAB installed on your system, the extension automatically checks the system path for the location of the MATLAB executable. If the MATLAB executable is not on the system path, you may need to manually set the `MATLAB.installPath` setting to the full path of your MATLAB installation. For example, `C:\Program Files\MATLAB\R2022b` (Windows&reg;), `/Applications/MATLAB_R2022b.app` (macOS), or `/usr/local/MATLAB/R2022b` (Linux&reg;).
 
@@ -98,6 +102,9 @@ You can help improve the extension by sending user experience information to Mat
 
 For more information, see the [MathWorks Privacy Policy](https://www.mathworks.com/company/aboutus/policies_statements.html).
 
+### MATLAB Prewarm Graphics Setting
+By default, MATLAB services are started early to improve the first-time performance of MATLAB figure rendering. To disable this behavior, set the `MATLAB.prewarmGraphics` setting to `false`.
+This setting is supported with MATLAB R2025a and later. For earlier releases, this setting is ignored.
 
 
 ## Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "language-matlab",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "language-matlab",
-			"version": "1.3.4",
+			"version": "1.3.5",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7396,9 +7396,9 @@
 			}
 		},
 		"node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.14"
@@ -13773,9 +13773,9 @@
 			}
 		},
 		"tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true
 		},
 		"to-buffer": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Edit MATLAB code with syntax highlighting, linting, navigation support, and more",
 	"icon": "public/L-Membrane_RGB_128x128.png",
 	"license": "MIT",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"engines": {
 		"vscode": "^1.67.0"
 	},
@@ -268,6 +268,18 @@
 					"type": "number",
 					"default": 0,
 					"markdownDescription": "The maximum number of characters a file can contain for features such as linting, code navigation, and symbol renaming to be enabled. Use `0` for no limit.",
+					"scope": "window"
+				},
+				"MATLAB.prewarmGraphics": {
+					"type": "boolean",
+					"default": true,
+					"description": "Prewarm graphics at MATLAB startup to improve performance of first-time graphics rendering.",
+					"scope": "window"
+				},
+				"MATLAB.defaultEditor": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Use Visual Studio Code instead of the MATLAB Editor to open and edit files using the `open` and `edit` commands. Certain file types always open in MATLAB by default — for example, live scripts saved in the binary Live Code file format (.mlx) and MATLAB app files (.mlapp).",
 					"scope": "window"
 				}
 			}

--- a/src/DefaultEditorService.ts
+++ b/src/DefaultEditorService.ts
@@ -1,0 +1,155 @@
+// Copyright 2025 The MathWorks, Inc.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import { exec } from 'child_process';
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { LanguageClient } from 'vscode-languageclient/node';
+import { MatlabState, MVM } from './commandwindow/MVM'
+import Notification from './Notifications'
+
+export default class DefaultEditorService {
+    private initialized = false;
+
+    constructor (private readonly context: vscode.ExtensionContext, private readonly client: LanguageClient, private readonly mvm: MVM) {
+        context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration(() => {
+                void this.handleConfigChanged()
+            })
+        )
+
+        mvm.on(MVM.Events.stateChanged, (oldState: MatlabState, newState: MatlabState) => {
+            if (oldState === newState) {
+                return;
+            }
+
+            if (newState === MatlabState.READY || newState === MatlabState.BUSY) {
+                if (!this.initialized) {
+                    this.initialized = true
+                    void this.handleConfigChanged()
+                }
+            } else {
+                this.initialized = false
+            }
+        });
+    }
+
+    /** Helper function: checks if a specific path from array of path strings exists and returns true if a path string is found in file system else returns false
+     * @param paths array of string paths to be checked in file system
+     * @returns path string if it exists in file system else null
+    */
+    private checkPath (paths: string[]): string | null {
+        for (const p of paths) {
+            if (fs.existsSync(p)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private getFallbackExecutablePaths (): string[] {
+        const appRoot = vscode.env.appRoot;
+        const platform = process.platform;
+        const fallbackPaths: string[] = [];
+
+        if (platform === 'win32') {
+            // appRoot: C:\Program Files\Microsoft VS Code\resources\app
+            // Executable: C:\Program Files\Microsoft VS Code\Code.exe
+            fallbackPaths.push(
+                path.join(path.dirname(path.dirname(appRoot)), 'Code.exe')
+            );
+        } else if (platform === 'darwin') {
+            // appRoot: /Applications/Visual Studio Code.app/Contents/Resources/app
+            // Executable: /Applications/Visual Studio Code.app/Contents/MacOS/Electron
+            // or /Applications/Visual Studio Code.app/Contents/MacOS/Visual Studio Code
+            // Try both
+            const appDir = path.dirname(path.dirname(appRoot)); // .../Visual Studio Code.app/Contents
+            fallbackPaths.push(
+                path.join(appDir, 'MacOS', 'Visual Studio Code'),
+                path.join(appDir, 'MacOS', 'Electron')
+            );
+        } else {
+            // Linux
+            // appRoot: /usr/share/code/resources/app
+            // Executable: /usr/share/code/code
+            fallbackPaths.push(
+                path.join(path.dirname(path.dirname(appRoot)), 'code')
+            );
+        }
+        return fallbackPaths
+    }
+
+    /** Look into most probable installation paths based on OS to find VS Code executable path
+     * @returns path string found for VS Code executable
+    */
+    public getVSCodePath (): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const fallbackPaths = this.getFallbackExecutablePaths()
+
+            const platform = os.platform();
+
+            const command = platform === 'win32' ? 'where code' : 'which code';
+
+            exec(command, (error, stdout, stderr) => {
+                if ((error == null) && typeof stdout === 'string' && stdout !== '') {
+                    resolve(stdout.trim().split('\n').filter(Boolean)[0].trim());
+                } else {
+                    const fallback = this.checkPath(fallbackPaths);
+                    if (typeof fallback === 'string' && fallback.length > 0) {
+                        resolve(fallback);
+                    } else {
+                        reject(new Error('MATLAB Default Editor: Error getting VS Code executable path'));
+                    }
+                }
+            });
+        });
+    }
+
+    /**
+     * Handles the notification that MATLAB failed to set VS Code as default editor successfully. This most likely indicates that
+     * either VS Code is not installed in a default location and 'code' is not added to PATH.
+     * @param matlabConfig VsCode Workspace object for MATLAB extension configuration
+     */
+    public async handleVsCodePathError (matlabConfig: vscode.WorkspaceConfiguration): Promise<void> {
+        const message = 'Unable to set MATLAB default editor to Visual Studio Code. Check that VS Code is installed in a default location or add it to the system PATH.'
+        const availableCmds = await vscode.commands.getCommands()
+        const options = ['Add VS Code to PATH']
+
+        if (availableCmds.includes('workbench.action.installCommandLine')) {
+            vscode.window.showErrorMessage(message, ...options).then(choice => {
+                switch (choice) {
+                    case options[0]:
+                        void vscode.commands.executeCommand('workbench.action.installCommandLine')
+                        break
+                }
+            }, reject => console.error(reject))
+        } else {
+            vscode.window.showErrorMessage(message).then(choice => { /* empty */ }, reject => console.error(reject))
+        }
+        void matlabConfig.update('defaultEditor', false, true);
+    }
+
+    /**
+     * Handles config state management. Finds VS Code executable path when defaultEditor config is enabled and displays an error message if path not found.
+     */
+    public handleConfigChanged (): void {
+        const configuration = vscode.workspace.getConfiguration('MATLAB')
+        if ((configuration.get<boolean>('defaultEditor') ?? true)) {
+            this.getVSCodePath().then(validPath => {
+                void this.sendExecutablePathNotification(validPath)
+            }).catch(err => {
+                console.error(err)
+                void this.handleVsCodePathError(configuration)
+            });
+        }
+    }
+
+    /**
+    * Sends notification to language server to update default editor to VS Code.
+    * @param executablePath The path to VS Code
+    */
+    public sendExecutablePathNotification (executablePath: string): void {
+        void this.client.sendNotification(Notification.EditorExecutablePath, executablePath)
+    }
+}

--- a/src/Notifications.ts
+++ b/src/Notifications.ts
@@ -51,7 +51,10 @@ enum Notification {
     LicensingServerUrl = 'licensing/server/url',
     LicensingData = 'licensing/data',
     LicensingDelete = 'licensing/delete',
-    LicensingError = 'licensing/error'
+    LicensingError = 'licensing/error',
+
+    // Default Editor
+    EditorExecutablePath = 'matlab/otherEditor'
 }
 
 export default Notification

--- a/src/commandwindow/CommandWindow.ts
+++ b/src/commandwindow/CommandWindow.ts
@@ -66,7 +66,7 @@ const ACTION_KEYS = {
 
     MOVE_TO_POSITION_IN_LINE: (n: number) => ESC + '[' + n.toString() + 'G',
     CLEAR_AND_MOVE_TO_BEGINNING: ESC + '[0G' + ESC + '[0J',
-    CLEAR_COMPLETELY: ESC + '[2J' + ESC + '[1;1H',
+    CLEAR_COMPLETELY: ESC + '[2J' + ESC + '[3J' + ESC + '[1;1H',
 
     QUERY_CURSOR: ESC + '[6n',
     SET_CURSOR_STYLE_TO_BAR: ESC + '[5 q'
@@ -707,7 +707,6 @@ export default class CommandWindow implements vscode.Pseudoterminal {
      */
     clear (): void {
         this._writeEmitter.fire(ACTION_KEYS.CLEAR_COMPLETELY)
-        void vscode.commands.executeCommand('workbench.action.terminal.clear');
         this._setToEmptyPrompt();
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import DeprecationPopupService from './DeprecationPopupService'
 import { SectionModel } from './model/SectionModel'
 import SectionStylingService from './styling/SectionStylingService'
 import MatlabDebugger from './debug/MatlabDebugger'
+import DefaultEditorService from './DefaultEditorService'
 
 let client: LanguageClient
 const OPEN_SETTINGS_ACTION = 'workbench.action.openSettings'
@@ -36,6 +37,8 @@ const MATLAB_ENABLE_SIGN_IN_COMMAND = 'matlab.enableSignIn'
 let telemetryLogger: TelemetryLogger
 
 let deprecationPopupService: DeprecationPopupService
+
+let defaultEditorService: DefaultEditorService
 
 let sectionModel: SectionModel;
 let sectionStylingService: SectionStylingService;
@@ -143,6 +146,8 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 
     deprecationPopupService = new DeprecationPopupService(context)
     deprecationPopupService.initialize(client)
+
+    defaultEditorService = new DefaultEditorService(context, client, mvm)
 
     sectionModel = new SectionModel()
     sectionModel.initialize(client as Notifier);

--- a/src/test/tools/tester/TestSuite.ts
+++ b/src/test/tools/tester/TestSuite.ts
@@ -16,10 +16,7 @@ export class TestSuite {
     private readonly releaseQuality: ReleaseQuality
 
     public constructor () {
-        this.storageFolder = path.join(__dirname, '..', '..', '..', '..', '.vscode-test', 'test-resources')
-        if (os.platform() === 'darwin') {
-            this.storageFolder = os.tmpdir()
-        }
+        this.storageFolder = path.join(__dirname, '..', '..', '..', '..', 's')
         this.mochaConfig = path.join(__dirname, '..', 'config', '.mocharc.js')
         const pjson = require(path.resolve('package.json')) // eslint-disable-line
         this.vsixPath = path.resolve(`${pjson.name}-${pjson.version}.vsix`) // eslint-disable-line

--- a/src/test/ui/debugging.test.ts
+++ b/src/test/ui/debugging.test.ts
@@ -2,7 +2,7 @@
 import { VSCodeTester } from '../tools/tester/VSCodeTester'
 import { before, afterEach, after } from 'mocha';
 
-suite('Debugging Smoke Tests', () => {
+suite('Debugging UI Tests', () => {
     let vs: VSCodeTester
 
     before(async () => {

--- a/src/test/ui/editor.test.ts
+++ b/src/test/ui/editor.test.ts
@@ -1,0 +1,22 @@
+// Copyright 2025 The MathWorks, Inc.
+import { VSCodeTester } from '../tools/tester/VSCodeTester'
+import { before, after } from 'mocha';
+
+suite('Editor UI Tests', () => {
+    let vs: VSCodeTester
+
+    before(async () => {
+        vs = new VSCodeTester();
+    });
+
+    after(async () => {
+        await vs.disconnectFromMATLAB()
+    });
+
+    test('Test editor section', async () => {
+        await vs.openEditor('hSectionsScript.m')
+        await vs.assertMATLABConnected()
+        await vs.assertDecorationOnLine(5, 'Line 5 should have section decoration')
+        await vs.closeActiveEditor()
+    })
+});

--- a/src/test/ui/execution.test.ts
+++ b/src/test/ui/execution.test.ts
@@ -2,7 +2,7 @@
 import { VSCodeTester } from '../tools/tester/VSCodeTester'
 import { before, after } from 'mocha';
 
-suite('Execution Smoke Tests', () => {
+suite('Execution UI Tests', () => {
     let vs: VSCodeTester
 
     before(async () => {

--- a/src/test/ui/terminal.test.ts
+++ b/src/test/ui/terminal.test.ts
@@ -3,7 +3,7 @@ import { VSCodeTester } from '../tools/tester/VSCodeTester'
 import { before, afterEach, after } from 'mocha';
 import { Key } from 'selenium-webdriver';
 
-suite('Terminal Smoke Tests', () => {
+suite('Terminal UI Tests', () => {
     let vs: VSCodeTester
 
     before(async () => {


### PR DESCRIPTION
Prepping changes for v1.3.5 update of the MATLAB extension for VS Code.

See CHANGELOG.md for the changes included.

Fixes #125
Fixes #254 
Fixes #272 