### PR TITLE
Fix terminal startup on cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"onDebugResolve:matlab",
 		"onDebugDynamicConfigurations:matlab",
 		"onLanguage:matlab",
-		"onTerminalProfile:matlab.terminal-profile"
+		"onTerminalProfile:matlab.terminal-profile",
+		"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Hi,

I opened [this bug report](https://github.com/mathworks/MATLAB-extension-for-vscode/issues/313) and I found a fix that works in my local environment.

For context, v1.3.8 on Cursor does ever not start correctly and does not register the matlab connection properly but displays this error:
`no terminal profile provider registered of id "matlab.terminal-profile"`
It looks like this is a Cursor specific problem, which is not there on v1.3.3 and not present in vs code probably due to the different implementation of the terminals between the two softwares.

To my understanding the problem is that between v1.3.3 and v1.3.8 more work is done before initialization of the terminal and there might be a timing issue. My workaround fixes this by simply activating onStartupFinished instead.
