### PR TITLE
Feature Yellow Warning: add yellow warning in vscode cmd

### DIFF
--- a/src/commandwindow/CommandWindow.ts
+++ b/src/commandwindow/CommandWindow.ts
@@ -61,6 +61,7 @@ const ACTION_KEYS = {
     INVERT_COLORS: ESC + '[7m',
     RESTORE_COLORS: ESC + '[27m',
     RED_FOREGROUND: ESC + '[31m',
+    YELLOW_FOREGROUND: ESC + '[33m',
     ALL_DEFAULT_COLORS: ESC + '[0m',
 
     COPY: '\x03',
@@ -724,7 +725,13 @@ export default class CommandWindow implements vscode.Pseudoterminal {
     addOutput (output: TextEvent): void {
         if (this._initialized) {
             if (output.stream === 0) {
-                this.handleText(output.text, true);
+                if (output.text.startsWith('Warning:')) {
+                    this._writeEmitter.fire(ACTION_KEYS.YELLOW_FOREGROUND);
+                    this.handleText(output.text, true);
+                    this._writeEmitter.fire(ACTION_KEYS.ALL_DEFAULT_COLORS);
+                } else {
+                    this.handleText(output.text, true);
+                }
             } else {
                 this._writeEmitter.fire(ACTION_KEYS.RED_FOREGROUND);
                 this.handleText(output.text, true);


### PR DESCRIPTION
This change updates command window rendering so MATLAB output that begins with `Warning:` is displayed in yellow in the VS Code terminal.

<img width="396" height="282" alt="image" src="https://github.com/user-attachments/assets/76b96fb6-5c21-4923-9be1-83d9b7884198" />


**What changed**
1. Added a yellow ANSI foreground escape sequence to terminal action keys.  
2. Updated output handling logic to:
1. color `Warning:`-prefixed text yellow,  
2. keep normal stdout unchanged,  
3. keep non-stdout/error stream output red.

**Why**
Warnings were visually indistinguishable from normal output. This improves readability and makes warnings easier to spot without changing command behavior.

**Note**  
This implementation is a pragmatic workaround. A better long-term approach would be for MATLAB to return a dedicated stream value for warnings (for example, stream = 2 for warnings) so warning rendering can rely on explicit metadata instead of text-prefix matching. Given current constraints, this solution is effective and low risk.